### PR TITLE
choleskify vs triangularize

### DIFF
--- a/src/PSDMatrices.jl
+++ b/src/PSDMatrices.jl
@@ -80,14 +80,6 @@ function triangularize_factor(M::PSDMatrix)
     return PSDMatrix(UpperTriangular(R))
 end
 
-function choleskify(M::PSDMatrix)
-    if M.R isa UpperTriangular
-        return Cholesky(nonnegative_diagonal(M.R), 'U', 0)
-    end
-    errormsg = "choleskify() is only defined for PSDMatrix types with upper triangular factors."
-    throw(MethodError(errormsg))
-end
-
 function nonnegative_diagonal(R)
     signs = signbit.(diag(R))
     R .*= (1 .- 2 .* signs)
@@ -98,7 +90,6 @@ export PSDMatrix
 export add_cholesky
 export add_qr
 export triangularize_factor
-export choleskify
 export X_A_Xt
 export X_A_Xt!
 

--- a/src/PSDMatrices.jl
+++ b/src/PSDMatrices.jl
@@ -84,7 +84,7 @@ function choleskify(M::PSDMatrix)
     if M.R isa UpperTriangular
         return Cholesky(nonnegative_diagonal(M.R))
     end
-    errormsg = "choleskify() is only defined for PSDMatrix types with triangular factors."
+    errormsg = "choleskify() is only defined for PSDMatrix types with upper triangular factors."
     throw(MethodError(errormsg))
 end
 

--- a/src/PSDMatrices.jl
+++ b/src/PSDMatrices.jl
@@ -80,12 +80,6 @@ function triangularize_factor(M::PSDMatrix)
     return PSDMatrix(UpperTriangular(R))
 end
 
-function nonnegative_diagonal(R)
-    signs = signbit.(diag(R))
-    R .*= (1 .- 2 .* signs)
-    return R
-end
-
 export PSDMatrix
 export add_cholesky
 export add_qr

--- a/src/PSDMatrices.jl
+++ b/src/PSDMatrices.jl
@@ -82,7 +82,7 @@ end
 
 function choleskify(M::PSDMatrix)
     if M.R isa UpperTriangular
-        return Cholesky(nonnegative_diagonal(M.R))
+        return Cholesky(nonnegative_diagonal(M.R), 'U', 0)
     end
     errormsg = "choleskify() is only defined for PSDMatrix types with upper triangular factors."
     throw(MethodError(errormsg))

--- a/src/PSDMatrices.jl
+++ b/src/PSDMatrices.jl
@@ -35,12 +35,6 @@ end
 det(M::PSDMatrix) = det(M.R)^2
 logdet(M::PSDMatrix) = 2 * logdet(M.R)
 
-function nonnegative_diagonal(R)
-    signs = signbit.(diag(R))
-    R .*= (1 .- 2 .* signs)
-    return R
-end
-
 # Custom functions
 
 X_A_Xt(; A::PSDMatrix, X::AbstractMatrix) = PSDMatrix(A.R * X')
@@ -60,19 +54,33 @@ end
 function add_qr(A::PSDMatrix, B::PSDMatrix)
     stack = vcat(A.R, B.R)
     matrix = PSDMatrix(stack)
-    return choleskify_factor(matrix)
+    return triangularize_factor(matrix)
 end
 
-function choleskify_factor(M::PSDMatrix)
+function triangularize_factor(M::PSDMatrix)
     R = qr(M.R).R
-    R = nonnegative_diagonal(R)
     return PSDMatrix(UpperTriangular(R))
+end
+
+function choleskify(M::PSDMatrix)
+    if M.R isa UpperTriangular
+        return Cholesky(nonnegative_diagonal(M.R))
+    end
+    errormsg = "choleskify() is only defined for PSDMatrix types with triangular factors."
+    throw(MethodError(errormsg))
+end
+
+function nonnegative_diagonal(R)
+    signs = signbit.(diag(R))
+    R .*= (1 .- 2 .* signs)
+    return R
 end
 
 export PSDMatrix
 export add_cholesky
 export add_qr
-export choleskify_factor
+export triangularize_factor
+export choleskify
 export X_A_Xt
 export X_A_Xt!
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -62,7 +62,14 @@ eltypes = (Int64, Float64, BigFloat)
             end
             @test Matrix(add_qr(S, S)) ≈ Matrix(S) + Matrix(S)
             if (size(M, 1) >= size(M, 2))
-                @test choleskify_factor(S).R ≈ cholesky(Matrix(S)).U
+                tri = triangularize_factor(S)
+                chol = cholesky(Matrix(S))
+                @test begin
+                    tri.R' * tri.R ≈ chol.U' * chol.U
+                    tri.R isa UpperTriangular
+                end
+                @test choleskify(tri).U ≈ chol.U
+                @test_throws MethodError choleskify(S)
                 @test Matrix(add_cholesky(S, S)) ≈ Matrix(S) + Matrix(S)
             end
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -64,15 +64,8 @@ eltypes = (Int64, Float64, BigFloat)
             @test Matrix(add_qr(S, S)) ≈ Matrix(S) + Matrix(S)
             if (size(M, 1) >= size(M, 2))
                 @test Matrix(add_cholesky(S, S)) ≈ Matrix(S) + Matrix(S)
-
                 tri = triangularize_factor(S)
-                chol = cholesky(Matrix(S))
-                # Assert that `tri` is basically a Cholesky factorisation, 
-                # but without guaranteed positive diagonal elements
-                @test begin
-                    tri.R isa UpperTriangular
-                    tri.R' * tri.R ≈ chol.U' * chol.U
-                end
+                @test tri.R isa UpperTriangular
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -73,8 +73,6 @@ eltypes = (Int64, Float64, BigFloat)
                     tri.R isa UpperTriangular
                     tri.R' * tri.R ≈ chol.U' * chol.U
                 end
-                @test choleskify(tri).U ≈ chol.U
-                @test_throws MethodError choleskify(S)  # non-triangular factors
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,6 +66,7 @@ eltypes = (Int64, Float64, BigFloat)
                 @test Matrix(add_cholesky(S, S)) ≈ Matrix(S) + Matrix(S)
                 tri = triangularize_factor(S)
                 @test tri.R isa UpperTriangular
+                @test Matrix(tri) ≈ Matrix(S)
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,15 +63,18 @@ eltypes = (Int64, Float64, BigFloat)
             end
             @test Matrix(add_qr(S, S)) ≈ Matrix(S) + Matrix(S)
             if (size(M, 1) >= size(M, 2))
+                @test Matrix(add_cholesky(S, S)) ≈ Matrix(S) + Matrix(S)
+
                 tri = triangularize_factor(S)
                 chol = cholesky(Matrix(S))
+                # Assert that `tri` is basically a Cholesky factorisation, 
+                # but without guaranteed positive diagonal elements
                 @test begin
-                    tri.R' * tri.R ≈ chol.U' * chol.U
                     tri.R isa UpperTriangular
+                    tri.R' * tri.R ≈ chol.U' * chol.U
                 end
                 @test choleskify(tri).U ≈ chol.U
-                @test_throws MethodError choleskify(S)
-                @test Matrix(add_cholesky(S, S)) ≈ Matrix(S) + Matrix(S)
+                @test_throws MethodError choleskify(S)  # non-triangular factors
             end
         end
     end


### PR DESCRIPTION
If you agree with #20 (splitting `choleskify_factors` into `triangularize_factors` and `choleskify`), here is an implementation. Personally, I prefer it this way. But if you disagree, no worries, then I will just delete this. 