### PR TITLE
Implement `LinearAlgebra.diag`

### DIFF
--- a/src/PSDMatrices.jl
+++ b/src/PSDMatrices.jl
@@ -42,14 +42,7 @@ function logdet(M::PSDMatrix)
     return 2 * logdet(M.R)
 end
 
-function diag(M::PSDMatrix)
-    out = similar(M.R, size(M.R, 2))
-    @simd ivdep for i in axes(M.R, 2)
-        col = view(M.R, :, i)
-        out[i] = sum(abs2, col)
-    end
-    return out
-end
+diag(M::PSDMatrix) = sum(abs2, M.R, dims=1)
 
 function confirm_factor_is_square(M::PSDMatrix)
     if size(M.R, 1) != size(M.R, 2)

--- a/src/PSDMatrices.jl
+++ b/src/PSDMatrices.jl
@@ -3,7 +3,7 @@ module PSDMatrices
 
 import Base: \, /, size, inv, copy, copy!, ==, show, similar, Matrix
 using LinearAlgebra
-import LinearAlgebra: det, logdet
+import LinearAlgebra: det, logdet, diag
 
 struct PSDMatrix{T,FactorType} <: AbstractMatrix{T}
     R::FactorType
@@ -40,6 +40,15 @@ end
 function logdet(M::PSDMatrix)
     confirm_factor_is_square(M)
     return 2 * logdet(M.R)
+end
+
+function diag(M::PSDMatrix)
+    out = similar(M.R, size(M.R, 2))
+    @simd ivdep for i in axes(M.R, 2)
+        col = view(M.R, :, i)
+        out[i] = sum(abs2, col)
+    end
+    return out
 end
 
 function confirm_factor_is_square(M::PSDMatrix)

--- a/src/PSDMatrices.jl
+++ b/src/PSDMatrices.jl
@@ -42,7 +42,11 @@ function logdet(M::PSDMatrix)
     return 2 * logdet(M.R)
 end
 
-diag(M::PSDMatrix) = sum(abs2, M.R, dims=1)
+function diag(M::PSDMatrix)
+    out = similar(M.R, size(M.R, 2))
+    sum!(abs2, out', M.R)
+    return out
+end
 
 function confirm_factor_is_square(M::PSDMatrix)
     if size(M.R, 1) != size(M.R, 2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,7 @@ eltypes = (Int64, Float64, BigFloat)
         end
 
         @testset "LinearAlgebra" begin
+            @test diag(S) ≈ diag(Matrix(S))
             if size(M, 1) == size(M, 2)
                 @test det(S) ≈ det(Matrix(S))
                 @test logdet(S) ≈ logdet(Matrix(S))


### PR DESCRIPTION
This is __much__ more efficient than calling `diag(Matrix(::PSDMatrix))`:

```julia
using PSDMatrices, BenchmarkTools, LinearAlgebra

R = rand(1,1);
S = PSDMatrix(R);
@btime diag(Matrix(S));
# 325.842 ns (2 allocations: 128 bytes)
@btime diag(S);
# 40.963 ns (1 allocation: 64 bytes)

R = rand(10_000,10_000);
S = PSDMatrix(R);
@btime diag(Matrix(S));
# 11.963 s (4 allocations: 763.02 MiB)
@btime diag(S);
# 52.355 ms (2 allocations: 78.17 KiB)
```

Minor remark: I considered implementing the shorter
```julia
diag(S::PSDMatrix) = map(c -> sum(abs2, c), eachcol(S.R))
```
but it was (very) slightly slower for smaller matrices. 