### PR TITLE
Fix `logdet` issues by instead implementing `logabsdet`

### DIFF
--- a/src/PSDMatrices.jl
+++ b/src/PSDMatrices.jl
@@ -3,7 +3,7 @@ module PSDMatrices
 
 import Base: \, /, size, inv, copy, copy!, ==, show, similar, Matrix
 using LinearAlgebra
-import LinearAlgebra: det, logdet, diag
+import LinearAlgebra: det, logabsdet, diag
 
 struct PSDMatrix{T,FactorType} <: AbstractMatrix{T}
     R::FactorType
@@ -37,9 +37,10 @@ function det(M::PSDMatrix)
     return det(M.R)^2
 end
 
-function logdet(M::PSDMatrix)
+function logabsdet(M::PSDMatrix)
     confirm_factor_is_square(M)
-    return 2 * logdet(M.R)
+    _logabsdet, _sign = logabsdet(M.R)
+    return 2 * _logabsdet, _sign^2
 end
 
 function diag(M::PSDMatrix)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,11 +6,12 @@ using Suppressor
 M_square = [1 1; 2 20]
 M_tall = [1 1; 2 20; 3 30]
 M_wide = [1 1 1; 2 20 200]
+M_neg = -ones(1,1)
 eltypes = (Int64, Float64, BigFloat)
 
 @testset "PSDMatrices.jl" begin
     @testset "eltype=$t | shape=$(size(Mbase))" for t in eltypes,
-        Mbase in (M_square, M_tall, M_wide)
+        Mbase in (M_square, M_tall, M_wide, M_neg)
 
         M = t.(Mbase)
         S = PSDMatrix(M)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ using Suppressor
 M_square = [1 1; 2 20]
 M_tall = [1 1; 2 20; 3 30]
 M_wide = [1 1 1; 2 20 200]
-M_neg = -ones(1,1)
+M_neg = -ones(1, 1)
 eltypes = (Int64, Float64, BigFloat)
 
 @testset "PSDMatrices.jl" begin


### PR DESCRIPTION
## The issue
Previously, we had cases where `logdet` fails even though the `PSDMatrix` of interest has a well-defined log-determinant:  
```julia
using PSDMatrices, LinearAlgebra
M = PSDMatrix(-I(3))
logdet(Matrix(M)) # correctly returns 0.0
logdet(M) # fails
```

## The fix
`LinearAlgebra.logdet` is actually implemented via `logabsdet`: 
https://github.com/JuliaLang/julia/blob/master/stdlib/LinearAlgebra/src/generic.jl#L1609-L1612.
So, let's overload `logabsdet` instead! The formula here: Multiply the log-abs-det with 2, but square the sign. Now everything works!