### PR TITLE
Remove keyword arguments from `X_A_Xt` and `X_A_Xt!` and add AbstractMatrix fallbacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
-          - '1.7'
+          - '1'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PSDMatrices"
 uuid = "fe68d972-6fd8-4755-bdf0-97d4c54cefdc"
 authors = ["Nathanael Bosch <nathanael.bosch@gmail.com> and contributors"]
-version = "0.4.7"
+version = "0.5.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/PSDMatrices.jl
+++ b/src/PSDMatrices.jl
@@ -71,9 +71,10 @@ end
 
 # Custom functions
 
-X_A_Xt(A::AbstractMatrix, X::AbstractMatrix) = X * A * X'
+X_A_Xt(A::Number, X::Number) = X * A * X'
+X_A_Xt(A::AbstractMatrix, X::AbstractVecOrMat) = X * A * X'
 X_A_Xt(A::PSDMatrix, X::AbstractMatrix) = PSDMatrix(A.R * X')
-X_A_Xt!(out::AbstractMatrix, A::AbstractMatrix, X::AbstractMatrix) = 
+X_A_Xt!(out::AbstractMatrix, A::AbstractMatrix, X::AbstractMatrix) =
     (out .= X * A * X'; out)
 function X_A_Xt!(out::PSDMatrix, A::PSDMatrix, X::AbstractMatrix)
     mul!(out.R, A.R, X')

--- a/src/PSDMatrices.jl
+++ b/src/PSDMatrices.jl
@@ -73,7 +73,8 @@ end
 
 X_A_Xt(A::AbstractMatrix, X::AbstractMatrix) = X * A * X'
 X_A_Xt(A::PSDMatrix, X::AbstractMatrix) = PSDMatrix(A.R * X')
-X_A_Xt!(out::AbstractMatrix, A::PSDMatrix, X::AbstractMatrix) = (out .= X * A * X'; out)
+X_A_Xt!(out::AbstractMatrix, A::AbstractMatrix, X::AbstractMatrix) = 
+    (out .= X * A * X'; out)
 function X_A_Xt!(out::PSDMatrix, A::PSDMatrix, X::AbstractMatrix)
     mul!(out.R, A.R, X')
     return out

--- a/src/PSDMatrices.jl
+++ b/src/PSDMatrices.jl
@@ -71,13 +71,13 @@ end
 
 # Custom functions
 
-X_A_Xt(; A::PSDMatrix, X::AbstractMatrix) = PSDMatrix(A.R * X')
-X_A_Xt(A::PSDMatrix, X::AbstractMatrix) = X_A_Xt(A=A, X=X)
-function X_A_Xt!(out::PSDMatrix; A::PSDMatrix, X::AbstractMatrix)
+X_A_Xt(A::AbstractMatrix, X::AbstractMatrix) = X * A * X'
+X_A_Xt(A::PSDMatrix, X::AbstractMatrix) = PSDMatrix(A.R * X')
+X_A_Xt!(out::AbstractMatrix, A::PSDMatrix, X::AbstractMatrix) = (out .= X * A * X'; out)
+function X_A_Xt!(out::PSDMatrix, A::PSDMatrix, X::AbstractMatrix)
     mul!(out.R, A.R, X')
     return out
 end
-X_A_Xt!(out::PSDMatrix, A::PSDMatrix, X::AbstractMatrix) = X_A_Xt!(out, A=A, X=X)
 
 function add_cholesky(A::PSDMatrix, B::PSDMatrix)
     sum_dense = Matrix(A) + Matrix(B)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -59,7 +59,7 @@ eltypes = (Int64, Float64, BigFloat)
 
             SM = Matrix(S)
             @test X_A_Xt(SM, X) ≈ X * SM * X'
-            @test X_A_Xt!(copy(SM), SM, X) ≈ X_A_Xt(SM, X) 
+            @test X_A_Xt!(copy(SM), SM, X) ≈ X_A_Xt(SM, X)
 
             @test Matrix(X_A_Xt(S, X)) ≈ X_A_Xt(Matrix(S), X)
             @test begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,9 +57,9 @@ eltypes = (Int64, Float64, BigFloat)
         @testset "Exports" begin
             @test norm(Matrix(S) - M' * M) == 0.0
 
-            @test let x=rand(t), a=rand(t)
+            @test let x = rand(t), a = rand(t)
                 X_A_Xt(a, x) ≈ x * a * x'
-            end 
+            end
 
             SM = Matrix(S)
             @test X_A_Xt(SM, X) ≈ X * SM * X'

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,7 +56,12 @@ eltypes = (Int64, Float64, BigFloat)
 
         @testset "Exports" begin
             @test norm(Matrix(S) - M' * M) == 0.0
-            @test Matrix(X_A_Xt(S, X)) ≈ X * Matrix(S) * X'
+
+            SM = Matrix(S)
+            @test X_A_Xt(SM, X) ≈ X * SM * X'
+            @test X_A_Xt!(copy(SM), SM, X) ≈ X_A_Xt(SM, X) 
+
+            @test Matrix(X_A_Xt(S, X)) ≈ X_A_Xt(Matrix(S), X)
             @test begin
                 product_eltype = typeof(one(eltype(X)) * one(eltype(S)))
                 S2 = PSDMatrix(zeros(product_eltype, size(S.R)...))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,6 +57,10 @@ eltypes = (Int64, Float64, BigFloat)
         @testset "Exports" begin
             @test norm(Matrix(S) - M' * M) == 0.0
 
+            @test let x=rand(t), a=rand(t)
+                X_A_Xt(a, x) ≈ x * a * x'
+            end 
+
             SM = Matrix(S)
             @test X_A_Xt(SM, X) ≈ X * SM * X'
             @test X_A_Xt!(copy(SM), SM, X) ≈ X_A_Xt(SM, X)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,17 +57,10 @@ eltypes = (Int64, Float64, BigFloat)
         @testset "Exports" begin
             @test norm(Matrix(S) - M' * M) == 0.0
             @test Matrix(X_A_Xt(S, X)) ≈ X * Matrix(S) * X'
-            @test Matrix(X_A_Xt(A=S, X=X)) ≈ X * Matrix(S) * X'
             @test begin
                 product_eltype = typeof(one(eltype(X)) * one(eltype(S)))
                 S2 = PSDMatrix(zeros(product_eltype, size(S.R)...))
                 X_A_Xt!(S2, S, X)
-                Matrix(S2) ≈ Matrix(X_A_Xt(S, X))
-            end
-            @test begin
-                product_eltype = typeof(one(eltype(X)) * one(eltype(S)))
-                S2 = PSDMatrix(zeros(product_eltype, size(S.R)...))
-                X_A_Xt!(S2, A=S, X=X)
                 Matrix(S2) ≈ Matrix(X_A_Xt(S, X))
             end
             @test Matrix(add_qr(S, S)) ≈ Matrix(S) + Matrix(S)


### PR DESCRIPTION
This will prevent some type piracy in ProbNumDiffEq.jl, as shown here: https://github.com/nathanaelbosch/ProbNumDiffEq.jl/issues/278#issuecomment-2217864515